### PR TITLE
Fix list and backtick in Virtualenv section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ En moins de 3mn vous avez une installation *Python/Django/Tequila* qui tourne su
 
 ### Virtualenv
 Create and activate a virtualenv for the project:
-    * `sudo pip3
-    * `virtualenv ./.venv` in the project folder
-    * `source ./.venv/bin/activate` to activate the virtualenv (on linux)
+* `sudo pip3`
+* `virtualenv ./.venv` in the project folder
+* `source ./.venv/bin/activate` to activate the virtualenv (on linux)
 Then run: `pip install -r requirements/base.txt`
 
 ### Database


### PR DESCRIPTION
* The `li` section was malformatted
* `sudo pip3` was missing the closing backtick